### PR TITLE
Small typo

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,5 +5,5 @@ title: "Learn Theme for Hugo"
 ![ClimateTown Knowledge Hub](images/index/knowledge-hub-banner.png)
 
 ---
-Welcome to the home page for the **ClimateTown Knowledge Hub**!🥳
+Welcome to the home page for the **Climate Town Knowledge Hub**!🥳
 


### PR DESCRIPTION
Made climate town 2 words instead of one on the starting page

## Describe your changes
 
 I have added a single space

## Related issue number/link

The main page you get started on is where that is. 🤓

Thanks for contributing! 🥳🚀🌳
