### PR TITLE
Configuring Svelte Kit build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^1.0.0",
+				"@sveltejs/adapter-static": "^1.0.0",
 				"@sveltejs/kit": "^1.0.0",
 				"svelte": "^3.54.0",
 				"svelte-check": "^2.9.2",
@@ -425,6 +426,15 @@
 			"dependencies": {
 				"import-meta-resolve": "^2.2.0"
 			},
+			"peerDependencies": {
+				"@sveltejs/kit": "^1.0.0"
+			}
+		},
+		"node_modules/@sveltejs/adapter-static": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0.tgz",
+			"integrity": "sha512-ZrQhRgSa2TsH+zvrOIKpdVsAhExafpsn+w6Gv1WHzV76RZ2XOYFa8xi6hEzRjeeAL++ac0dsZHzp8M4X7YIabg==",
+			"dev": true,
 			"peerDependencies": {
 				"@sveltejs/kit": "^1.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^1.0.0",
+		"@sveltejs/adapter-static": "^1.0.0",
 		"@sveltejs/kit": "^1.0.0",
 		"svelte": "^3.54.0",
 		"svelte-check": "^2.9.2",

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <!-- Emoji support -->
 <script>
+    import { base } from "$app/paths";
     import { onMount } from "svelte";
     onMount(() => twemoji.parse(document.body));
 </script>
@@ -17,12 +18,12 @@
     <!-- image of width 4em -->
     <img
         style="width: 4em"
-        src="/images/knowledge-hub-logo.png"
+        src="{base}/images/knowledge-hub-logo.png"
         alt="Knowledge Hub logo"
     />
 
-    <a href="/">Home</a>
-    <a href="/resources">Resources</a>
+    <a href="{base}/">Home</a>
+    <a href="{base}/resources">Resources</a>
 
     <a href="https://github.com/ClimateTown/knowledge-hub"
         >✍ Contribute on GitHub</a

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,7 @@
+<script>
+    import { base } from "$app/paths";
+</script>
+
 <h1>Climate Town Knowledge Hub</h1>
 <p>
     Welcome to the Climate Town Knowledge Hub, your “one stop shop” for
@@ -5,4 +9,8 @@
     contains a collection of online resources, initiatives, and tools suggested
     by the Climate Town Discord community.
 </p>
-<img src="/images/banner.jpg" alt="Climate banner image" style="width: 80%" />
+<img
+    src="{base}/images/banner.jpg"
+    alt="Climate banner image"
+    style="width: 80%"
+/>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,6 @@
 import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/kit/vite';
+
 
 // Adapted from [Stack overflow](https://stackoverflow.com/questions/72730192/how-to-host-a-sveltekit-adapter-static-project-on-github-pages)
 // and [adapter-static](https://github.com/sveltejs/kit/tree/master/packages/adapter-static#github-pages)
@@ -6,6 +8,7 @@ const dev = process.argv.includes('dev');
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+	preprocess: vitePreprocess(),
     kit: {
         adapter: adapter({
             pages: 'build',

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,15 +1,26 @@
-import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+import adapter from '@sveltejs/adapter-static';
+
+// Adapted from [Stack overflow](https://stackoverflow.com/questions/72730192/how-to-host-a-sveltekit-adapter-static-project-on-github-pages)
+// and [adapter-static](https://github.com/sveltejs/kit/tree/master/packages/adapter-static#github-pages)
+const dev = process.argv.includes('dev');
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
-
-	kit: {
-		adapter: adapter()
-	}
+    kit: {
+        adapter: adapter({
+            pages: 'build',
+            assets: 'build',
+            fallback: null,
+            precompress: false
+        }),
+		prerender: {
+			entries: ['*']
+		},
+        paths: {
+            base: dev ? '' : '/knowledge-hub'
+        }
+    }
 };
 
 export default config;
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import { sveltekit } from '@sveltejs/kit/vite';
 const config = {
 	plugins: [sveltekit()],
 	test: {
-		include: ['src/**/*.{test,spec}.{js,ts}'],
+		include: ['src/**/*.{test,spec}.{js,ts}']
 	}
 };
 


### PR DESCRIPTION
Updated build process for Svelte Kit to work with GitHub pages.

- [x] Added and configured `static-adapter` as per [`@svelte/static-adapter` readme](https://github.com/sveltejs/kit/tree/master/packages/adapter-static#github-pages), [Stack Overflow (some config options out of date in this article)](https://stackoverflow.com/questions/72730192/how-to-host-a-sveltekit-adapter-static-project-on-github-pages)
- [x] Updated links with `{base}` for GitHub pages hosting as per [Svelte Kit docs](https://kit.svelte.dev/docs/configuration#paths)
