### PR TITLE
Updating URL

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+hub.climatetownproductions.com

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,7 +4,7 @@ import { vitePreprocess } from '@sveltejs/kit/vite';
 
 // Adapted from [Stack overflow](https://stackoverflow.com/questions/72730192/how-to-host-a-sveltekit-adapter-static-project-on-github-pages)
 // and [adapter-static](https://github.com/sveltejs/kit/tree/master/packages/adapter-static#github-pages)
-const dev = process.argv.includes('dev');
+// const dev = process.argv.includes('dev'); // Disabled since using https://hub.climatetownproductions.com
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -20,7 +20,7 @@ const config = {
 			entries: ['*']
 		},
         paths: {
-            base: dev ? '' : '/knowledge-hub'
+            base: '' //dev ? '' : '/knowledge-hub'
         }
     }
 };


### PR DESCRIPTION
## Describe your changes
Update URL to serve site from `hub.climatetownproductions.com` rather than `climatetown.github.io/knowledge-hub`.

TODO:
- [x] Update URL base names in code
- [ ] Add CNAME in DNS config
- [x] Add config for GitHub repo (CNAME file)

