### PR TITLE
BUGFIX: Validate URL syntax in og:image preview scraping

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ pytest
 python-dotenv
 PyYAML
 tqdm
+validators

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ click==8.1.3
     # via
     #   black
     #   pip-tools
+decorator==5.1.1
+    # via validators
 distlib==0.3.6
     # via virtualenv
 exceptiongroup==1.1.0
@@ -136,6 +138,8 @@ uritemplate==4.1.1
     # via google-api-python-client
 urllib3==1.26.13
     # via requests
+validators==0.20.0
+    # via -r requirements.in
 virtualenv==20.19.0
     # via pre-commit
 wheel==0.38.4

--- a/scripts/get_og_previews.py
+++ b/scripts/get_og_previews.py
@@ -5,6 +5,7 @@ import yaml
 from bs4 import BeautifulSoup
 from loguru import logger
 from tqdm import tqdm
+import validators
 
 resources_file = Path("data") / "resources.yml"
 
@@ -72,7 +73,9 @@ def main():
             image = None
 
         if image:
-            resource["og_preview"] = image
+            # Check if image is valid URL
+            if validators.url(image):
+                resource["og_preview"] = image
 
     with resources_file.open("w") as f:
         yaml.dump(resources, f)


### PR DESCRIPTION
## Describe your changes
While scraping, Discord was giving an invalid link as the `og:image` tag (ie. `undefined//discord.com/assets/652f40427e1f5186ad54836074898279.png`). This was breaking the build process.

Now the scraper checks that all links follow valid URL syntax

## Related issue number/link
None
