### PR TITLE
Update build cron to run every 4 hours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches: [main, test-me/*]
   pull_request:
   schedule:
-  - cron: 0 * * * *
+  - cron: 0 */4 * * *
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
## Describe your changes
Build website cron job from every 1 hour to every 4 hours.

## Reasoning
Reason for regular builds in the first place is to refresh the YT feed (and other stuff, like image previews, and (future feature) checking for broken links etc).

### Pros for this change
I don't get emailed every hour on failing builds.

### Cons for this change
Larger lag in YouTube feed.

---
For now we merge to maintain my sanity 🙏
