### PR TITLE
Fix failing builds on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/configure-pages@v3
       id: pages
+      if: (github.ref == 'refs/heads/main') && (github.repository == 'ClimateTown/knowledge-hub')
     - uses: actions/setup-node@v3
       with:
         node-version: 19


### PR DESCRIPTION
## Describe your changes
Builds were failing on forks due to GH pages not being configured.

Updated config to only do pages related steps when action is run for this repo.

## Related issue number/link
N/A

Thanks for contributing! 🥳🚀🌳
