### PR TITLE
Resource data file converters and resource download button

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Get previews for resources
         run: |
           python scripts/get_og_previews.py
+      - name: Convert resources to CSV
+        run: |
+          python scripts/resource_converter.py -i data/resources.yml -o static/ClimateTown-Knowledge-Hub-resources.csv
       - run: npm install
         # - run: npm ci
       - run: npm run build

--- a/data/resource_onboarding_template.csv
+++ b/data/resource_onboarding_template.csv
@@ -1,0 +1,2 @@
+title,description,tags,url
+Example resource,This is an example resource.,"Climate Action,Other Tag",https://example.com

--- a/scripts/resource_converter.py
+++ b/scripts/resource_converter.py
@@ -1,0 +1,172 @@
+"""
+A small utility CLI app to convert Climate Town Knowledge Hub resources between YAML and CSV.
+"""
+
+import yaml
+import pandas as pd
+from pathlib import Path
+import json
+import jsonschema
+from copy import deepcopy
+import argparse
+
+CURRENT_FOLDER = Path(__file__).parent.absolute()
+ENCODING = "utf-8"
+
+RESOURCE_EXAMPLES = [
+    {
+        "title": "Example resource",
+        "description": "This is an example resource.",
+        "tags": ["Climate Action", "Other Tag"],
+        "url": "https://example.com",
+    },
+]
+
+
+class ResourcesSchema:
+    TITLE = "title"
+    DESCRIPTION = "description"
+    TAGS = "tags"
+    URL = "url"
+
+
+class Resources:
+    _data = None
+    _schema_path = CURRENT_FOLDER / "../data/resources.schema.json"
+
+    def __init__(self, data):
+        self._data = data
+
+    @classmethod
+    def from_yaml(cls, path):
+        with open(path, encoding=ENCODING) as f:
+            data = yaml.safe_load(f)
+        return cls(data)
+
+    @classmethod
+    def from_csv(cls, path):
+        df = pd.read_csv(path, encoding=ENCODING)
+        df["tags"] = df["tags"].apply(lambda x: x.split(","))
+        data = df.to_dict(orient="records")
+        return cls(data)
+
+    def check(self, schema_path=None):
+        # Use default schema path
+        if schema_path is None:
+            schema_path = self._schema_path
+
+        with open(schema_path, encoding=ENCODING) as f:
+            schema = json.load(f)
+
+        jsonschema.validate(self._data, schema)
+        return True
+
+    def to_yaml(self, path):
+        with open(path, "w", encoding=ENCODING) as f:
+            yaml.dump(
+                self._data, f, sort_keys=True, width=float("inf"), allow_unicode=True
+            )
+        return
+
+    def __dict__(self):
+        return deepcopy(self._data)
+
+    def to_csv(self, path):
+        return self.to_df().to_csv(path, index=False, encoding=ENCODING)
+
+    def to_df(self):
+        lst = deepcopy(self._data)
+        for item in lst:
+            item[ResourcesSchema.TAGS] = ",".join(item[ResourcesSchema.TAGS])
+
+        df = pd.DataFrame(lst)[
+            [
+                ResourcesSchema.TITLE,
+                ResourcesSchema.DESCRIPTION,
+                ResourcesSchema.TAGS,
+                ResourcesSchema.URL,
+            ]
+        ]
+        return df
+
+
+def path_is_yaml(path):
+    return path.lower().endswith(".yaml") or path.lower().endswith(".yml")
+
+
+def path_is_csv(path):
+    return path.lower().endswith(".csv")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        help="Input file path with YAML/YML or CSV extension.",
+    )
+    parser.add_argument(
+        "-e",
+        "--example-input-data",
+        action="store_true",
+        help="Use example input data instead of file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Output file path (optional) with YAML/YML or CSV extension.",
+    )
+    parser.add_argument(
+        "-c",
+        "--check",
+        action="store_true",
+        help="Check flag (optional, only if output is not specified)",
+    )
+
+    args = parser.parse_args()
+
+    if args.output is None and not args.check:
+        parser.error("One of --output or --check must be given.")
+
+    if args.example_input_data and args.input:
+        parser.error("--example-input-data and --input cannot be used together.")
+
+    if not args.example_input_data and not args.input:
+        parser.error("One of --example-input-data or --input must be given.")
+
+    if args.example_input_data:
+        resources = Resources(RESOURCE_EXAMPLES)
+
+    if args.input:
+        if path_is_yaml(args.input):
+            resources = Resources.from_yaml(args.input)
+        elif path_is_csv(args.input):
+            resources = Resources.from_csv(args.input)
+        else:
+            print("Input file extension not supported.")
+            exit(1)
+
+    if args.check:
+        try:
+            resources.check()
+            print("Validation successful. Resources match the schema.")
+        except jsonschema.exceptions.ValidationError as e:
+            print("Validation error:")
+            print(e)
+            exit(1)
+
+    if args.output:
+        if path_is_yaml(args.output):
+            resources.to_yaml(args.output)
+        elif path_is_csv(args.output):
+            resources.to_csv(args.output)
+        else:
+            print("Output file extension not supported.")
+            exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from "$app/paths";
   import { github_url } from "$lib/constants";
   import type { PageData } from "./$types";
   export let data: PageData;
@@ -117,6 +118,29 @@
     </svg>
     Edit
     <span class="sr-only">in a new tab</span>
+  </a>
+
+  <a
+    class="p-2 rounded-lg border-2 border-green-500 text-green-500"
+    href="{base}/ClimateTown-Knowledge-Hub-resources.csv"
+    download
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      class="w-6 h-6 inline"
+      viewBox="0 0 16 16"
+    >
+      <path
+        d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"
+      />
+      <path
+        d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"
+      />
+    </svg>
+    Download resources
   </a>
 </div>
 


### PR DESCRIPTION
## Describe your changes
Implement a CLI app to convert from YAML data file (used in the project) to CSV, and from CSV to YAML. Converting from YAML to CSV and back results in no diff.

This functionality will make the resources data more portable, and allow for easy onboarding of more resources. Also (included in this PR) allows for downloading of resources as CSV.

## Example use
See help docs
```
python scripts/resource_converter.py --help
```

Convert resources database to CSV
```
python scripts/resource_converter.py -i "data/resources.yml" -o "data/resources.csv"
```

Convert resources CSV to YAML
```
python scripts/resource_converter.py -i "data/resources.csv" -o "data/resources.yml"
```

Create template CSV to fill out (contents of `resource_onboarding_template.csv`)
```
python scripts/resource_converter.py --example-input-data -o "data/resource_onboarding_template.csv"
```

Check input file
```
python scripts/resource_converter.py -i "data/resources.csv" --check
```

Check input file before writing
```
python scripts/resource_converter.py -i "data/resources.csv" --check -o "data/resources.yml"
```


## Related issue number/link

Fixes #86
Fixes #131
