### PR TITLE
filter colours, card height fit row

### DIFF
--- a/data/resource_tags.schema.json
+++ b/data/resource_tags.schema.json
@@ -12,7 +12,8 @@
       },
       "color": {
         "type": "string",
-        "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+        "description": "please choose a color pairing with black text"
       }
     },
     "required": ["name"],

--- a/data/resource_tags.yml
+++ b/data/resource_tags.yml
@@ -2,37 +2,72 @@
 - name: ✨ Mod Choice
 - name: 🍞 Rollie's Choice
 - name: Activism
+  color: '#c8cdea'
 - name: Article
+  color: '#f1d7c0'
 - name: Bypass Paywalls
+  color: '#f1d7c0'
 - name: Climate Accountability
+  color: '#e0e9c9'
 - name: Climate Careers
+  color: '#e0e9c9'
 - name: Climate Journalism
+  color: '#e0e9c9'
 - name: Climate Models
+  color: '#e0e9c9'
 - name: Climate Tech
+  color: '#e0e9c9'
 - name: Collective Action
+  color: '#c8cdea'
 - name: Community
+  color: '#c8cdea'
 - name: Contacting representatives
+  color: '#e9cac9'
 - name: Discord
+  color: '#cfe2e0'
 - name: Drug Help
+  color: '#efebc2'
 - name: Education
+  color: '#efebc2'
 - name: Healthy Living
+  color: '#efebc2'
 - name: Individual Action
+  color: '#c8cdea'
 - name: location/Canada
+  color: '#dccdea'
 - name: location/Global
+  color: '#dccdea'
 - name: location/US
+  color: '#dccdea'
 - name: location/US/NYC
+  color: '#dccdea'
 - name: Organizations
+  color: '#cfe2e0'
 - name: Politics
+  color: '#e9cac9'
 - name: Politics/Global
+  color: '#e9cac9'
 - name: Politics/UK
+  color: '#e9cac9'
 - name: Politics/US
+  color: '#e9cac9'
 - name: Politics/Canada
+  color: '#e9cac9'
 - name: Professional Networking
+  color: '#cfe2e0'
 - name: Research
+  color: '#efebc2'
 - name: Sustainable Food
+  color: '#efebc2'
 - name: Tools
+  color: '#cfe2e0'
 - name: Unionize
+  color: '#c8cdea'
 - name: Vegan
+  color: '#efebc2'
 - name: Workers' rights
+  color: '#c8cdea'
 - name: Food Waste
+  color: '#efebc2'
 - name: Greenwashing
+  color: '#e0e9c9'

--- a/data/resource_tags.yml
+++ b/data/resource_tags.yml
@@ -2,72 +2,72 @@
 - name: ✨ Mod Choice
 - name: 🍞 Rollie's Choice
 - name: Activism
-  color: '#c8cdea'
+  color: "#c8cdea"
 - name: Article
-  color: '#f1d7c0'
+  color: "#f1d7c0"
 - name: Bypass Paywalls
-  color: '#f1d7c0'
+  color: "#f1d7c0"
 - name: Climate Accountability
-  color: '#e0e9c9'
+  color: "#e0e9c9"
 - name: Climate Careers
-  color: '#e0e9c9'
+  color: "#e0e9c9"
 - name: Climate Journalism
-  color: '#e0e9c9'
+  color: "#e0e9c9"
 - name: Climate Models
-  color: '#e0e9c9'
+  color: "#e0e9c9"
 - name: Climate Tech
-  color: '#e0e9c9'
+  color: "#e0e9c9"
 - name: Collective Action
-  color: '#c8cdea'
+  color: "#c8cdea"
 - name: Community
-  color: '#c8cdea'
+  color: "#c8cdea"
 - name: Contacting representatives
-  color: '#e9cac9'
+  color: "#e9cac9"
 - name: Discord
-  color: '#cfe2e0'
+  color: "#cfe2e0"
 - name: Drug Help
-  color: '#efebc2'
+  color: "#efebc2"
 - name: Education
-  color: '#efebc2'
+  color: "#efebc2"
 - name: Healthy Living
-  color: '#efebc2'
+  color: "#efebc2"
 - name: Individual Action
-  color: '#c8cdea'
+  color: "#c8cdea"
 - name: location/Canada
-  color: '#dccdea'
+  color: "#dccdea"
 - name: location/Global
-  color: '#dccdea'
+  color: "#dccdea"
 - name: location/US
-  color: '#dccdea'
+  color: "#dccdea"
 - name: location/US/NYC
-  color: '#dccdea'
+  color: "#dccdea"
 - name: Organizations
-  color: '#cfe2e0'
+  color: "#cfe2e0"
 - name: Politics
-  color: '#e9cac9'
+  color: "#e9cac9"
 - name: Politics/Global
-  color: '#e9cac9'
+  color: "#e9cac9"
 - name: Politics/UK
-  color: '#e9cac9'
+  color: "#e9cac9"
 - name: Politics/US
-  color: '#e9cac9'
+  color: "#e9cac9"
 - name: Politics/Canada
-  color: '#e9cac9'
+  color: "#e9cac9"
 - name: Professional Networking
-  color: '#cfe2e0'
+  color: "#cfe2e0"
 - name: Research
-  color: '#efebc2'
+  color: "#efebc2"
 - name: Sustainable Food
-  color: '#efebc2'
+  color: "#efebc2"
 - name: Tools
-  color: '#cfe2e0'
+  color: "#cfe2e0"
 - name: Unionize
-  color: '#c8cdea'
+  color: "#c8cdea"
 - name: Vegan
-  color: '#efebc2'
+  color: "#efebc2"
 - name: Workers' rights
-  color: '#c8cdea'
+  color: "#c8cdea"
 - name: Food Waste
-  color: '#efebc2'
+  color: "#efebc2"
 - name: Greenwashing
-  color: '#e0e9c9'
+  color: "#e0e9c9"

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -1,0 +1,12 @@
+export interface Resource {
+  title: string;
+  description: string;
+  url: string;
+  tags: Tag[];
+  og_preview: string | undefined;
+}
+
+export interface Tag {
+  name: string;
+  color?: string;
+}

--- a/src/routes/resources/+page.server.ts
+++ b/src/routes/resources/+page.server.ts
@@ -37,11 +37,11 @@ const sortAlphabeticallyEmojisFirst = (a: Tag, b: Tag) => {
 const parseResources = (tags: Tag[]) => {
   const file = fs.readFileSync("data/resources.yml", "utf8");
   const resources: Resource[] = parse(file);
-  for(const resource of resources) {
-    resource.tagInfo = []
-    for(const resTag of resource.tags) {
-      let matchIdx = tags.findIndex((tag: Tag) => tag.name === resTag)
-      resource.tagInfo.push(tags[matchIdx])
+  for (const resource of resources) {
+    resource.tagInfo = [];
+    for (const resTag of resource.tags) {
+      let matchIdx = tags.findIndex((tag: Tag) => tag.name === resTag);
+      resource.tagInfo.push(tags[matchIdx]);
     }
   }
   return resources.reverse();

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -2,7 +2,7 @@
   import { base } from "$app/paths";
   import { github_url } from "$lib/constants";
   import type { PageData } from "./$types";
-  import type { Tag } from "./+page.server";
+  import type { Tag } from "$lib/interfaces";
   export let data: PageData;
 
   let resources = data.payload.resources;
@@ -11,14 +11,13 @@
   // TODO: make this a user preference
   $: tagLogic = tagLogicAnd ? "and" : "or";
 
-  let tags = data.payload.tags;
-  let tag_names: string[] = tags.map((tag: Tag) => tag.name);
+  let tags: Tag[] = data.payload.tags;
   let tags_count = data.payload.tags_count;
   // Creating filter object
   let filterObject: any = {};
   filterObject["tags"] = {};
-  for (const tag in tag_names) {
-    filterObject.tags[tag] = false;
+  for (const tag of tags) {
+    filterObject.tags[tag.name] = false;
   }
 
   let removeWhitespace = (str: string) => {
@@ -39,7 +38,7 @@
     filterTags = new Set(filterTags);
 
     let minCommonTags = tagLogic ? filterTags.size : 1;
-    let resourceTags: Set<string>;
+    let resourceTags: Set<Tag>;
     for (resource of resources) {
       // Resource tags
       resourceTags = new Set(resource.tags);
@@ -228,7 +227,7 @@
   class="grid xl:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-x-4 gap-y-4 mt-3"
 >
   {#each displayedResources as resource}
-    <ListItem {...resource} />
+    <ListItem {resource} />
   {:else}
     <div>No resources here!</div>
   {/each}

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -12,7 +12,7 @@
   $: tagLogic = tagLogicAnd ? "and" : "or";
 
   let tags = data.payload.tags;
-  let tag_names: string[] = tags.map((tag: Tag) => tag.name)
+  let tag_names: string[] = tags.map((tag: Tag) => tag.name);
   let tags_count = data.payload.tags_count;
   // Creating filter object
   let filterObject: any = {};
@@ -175,7 +175,10 @@
       <div class="flex flex-row flex-wrap gap-2">
         {#each tags as tag}
           <!-- checkboxes -->
-          <div class="flex justify-between gap-2 rounded-full bg-gray-300" style:background-color={tag.color}>
+          <div
+            class="flex justify-between gap-2 rounded-full bg-gray-300"
+            style:background-color={tag.color}
+          >
             <label
               class="cursor-pointer py-2 px-3 rounded-full flex items-center gap-2"
               for={removeWhitespace(tag.name)}
@@ -189,7 +192,9 @@
               />
               <span>
                 {tag.name}
-                <span class="text-gray-500 italic">({tags_count[tag.name]})</span>
+                <span class="text-gray-500 italic"
+                  >({tags_count[tag.name]})</span
+                >
               </span>
             </label>
           </div>

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -2,6 +2,7 @@
   import { base } from "$app/paths";
   import { github_url } from "$lib/constants";
   import type { PageData } from "./$types";
+  import type { Tag } from "./+page.server";
   export let data: PageData;
 
   let resources = data.payload.resources;
@@ -11,12 +12,12 @@
   $: tagLogic = tagLogicAnd ? "and" : "or";
 
   let tags = data.payload.tags;
+  let tag_names: string[] = tags.map((tag: Tag) => tag.name)
   let tags_count = data.payload.tags_count;
   // Creating filter object
   let filterObject: any = {};
   filterObject["tags"] = {};
-  let tag: string;
-  for (tag of tags) {
+  for (const tag in tag_names) {
     filterObject.tags[tag] = false;
   }
 
@@ -174,21 +175,21 @@
       <div class="flex flex-row flex-wrap gap-2">
         {#each tags as tag}
           <!-- checkboxes -->
-          <div class="flex justify-between gap-2 rounded-full bg-gray-300">
+          <div class="flex justify-between gap-2 rounded-full bg-gray-300" style:background-color={tag.color}>
             <label
               class="cursor-pointer py-2 px-3 rounded-full flex items-center gap-2"
-              for={removeWhitespace(tag)}
+              for={removeWhitespace(tag.name)}
             >
               <input
                 type="checkbox"
                 class="appearance-none cursor-pointer w-6 h-6 bg-white rounded-full checked:bg-black transition duration-200"
-                bind:checked={filterObject.tags[tag]}
-                id={removeWhitespace(tag)}
-                name={removeWhitespace(tag)}
+                bind:checked={filterObject.tags[tag.name]}
+                id={removeWhitespace(tag.name)}
+                name={removeWhitespace(tag.name)}
               />
               <span>
-                {tag}
-                <span class="text-gray-500 italic">({tags_count[tag]})</span>
+                {tag.name}
+                <span class="text-gray-500 italic">({tags_count[tag.name]})</span>
               </span>
             </label>
           </div>

--- a/src/routes/resources/ListItem.svelte
+++ b/src/routes/resources/ListItem.svelte
@@ -6,11 +6,13 @@
   export let tagInfo: Array<Tag>;
 
   import { base } from "$app/paths";
-    import type { Tag } from "./+page.server";
+  import type { Tag } from "./+page.server";
 </script>
 
 <a href={url} target="_blank" rel="noreferrer">
-  <div class="flex flex-col rounded-lg shadow-lg transition ease-in-out hover:scale-105 h-full">
+  <div
+    class="flex flex-col rounded-lg shadow-lg transition ease-in-out hover:scale-105 h-full"
+  >
     {#if og_preview}
       <img
         height="190"
@@ -72,7 +74,10 @@
       <p class="mt-2 text-gray-700 grow">{description}</p>
       <div class="flex flex-wrap text-xs py-2">
         {#each tagInfo as tag}
-          <div class="bg-gray-200 rounded-lg whitespace-nowrap p-1 my-1 mr-2 " style:background-color={tag.color}>
+          <div
+            class="bg-gray-200 rounded-lg whitespace-nowrap p-1 my-1 mr-2 "
+            style:background-color={tag.color}
+          >
             {tag.name}
           </div>
         {/each}

--- a/src/routes/resources/ListItem.svelte
+++ b/src/routes/resources/ListItem.svelte
@@ -3,13 +3,14 @@
   export let url: string;
   export let description: string;
   export let og_preview: string | undefined;
-  export let tags: Array<string>;
+  export let tagInfo: Array<Tag>;
 
   import { base } from "$app/paths";
+    import type { Tag } from "./+page.server";
 </script>
 
 <a href={url} target="_blank" rel="noreferrer">
-  <div class="rounded-lg shadow-lg transition ease-in-out hover:scale-105">
+  <div class="flex flex-col rounded-lg shadow-lg transition ease-in-out hover:scale-105 h-full">
     {#if og_preview}
       <img
         height="190"
@@ -42,7 +43,7 @@
       </div>
     {/if}
 
-    <div class="m-3">
+    <div class="flex flex-col grow m-3">
       <div class="text-xl font-medium text-gray-900 mt-3">
         <span>
           {title}
@@ -68,11 +69,11 @@
           </svg>
         </span>
       </div>
-      <p class="mt-2 text-gray-700">{description}</p>
+      <p class="mt-2 text-gray-700 grow">{description}</p>
       <div class="flex flex-wrap text-xs py-2">
-        {#each tags as tag}
-          <div class="bg-gray-200 rounded-lg whitespace-nowrap p-1 my-1 mr-2 ">
-            {tag}
+        {#each tagInfo as tag}
+          <div class="bg-gray-200 rounded-lg whitespace-nowrap p-1 my-1 mr-2 " style:background-color={tag.color}>
+            {tag.name}
           </div>
         {/each}
       </div>

--- a/src/routes/resources/ListItem.svelte
+++ b/src/routes/resources/ListItem.svelte
@@ -1,26 +1,21 @@
 <script lang="ts">
-  export let title: string;
-  export let url: string;
-  export let description: string;
-  export let og_preview: string | undefined;
-  export let tagInfo: Array<Tag>;
-
   import { base } from "$app/paths";
-  import type { Tag } from "./+page.server";
+  import type { Resource } from "$lib/interfaces";
+  export let resource: Resource;
 </script>
 
-<a href={url} target="_blank" rel="noreferrer">
+<a href={resource.url} target="_blank" rel="noreferrer">
   <div
     class="flex flex-col rounded-lg shadow-lg transition ease-in-out hover:scale-105 h-full"
   >
-    {#if og_preview}
+    {#if resource.og_preview}
       <img
         height="190"
         width="330"
         loading="lazy"
         class="object-cover rounded-t-lg object-center h-48 w-full"
         alt="Website preview"
-        src={og_preview}
+        src={resource.og_preview}
       />
     {:else}
       <div
@@ -48,7 +43,7 @@
     <div class="flex flex-col grow m-3">
       <div class="text-xl font-medium text-gray-900 mt-3">
         <span>
-          {title}
+          {resource.title}
         </span>
         <span
           class="w-10 h-10 inline-flex items-center justify-center rounded-full bg-indigo-100 text-indigo-500"
@@ -71,9 +66,9 @@
           </svg>
         </span>
       </div>
-      <p class="mt-2 text-gray-700 grow">{description}</p>
+      <p class="mt-2 text-gray-700 grow">{resource.description}</p>
       <div class="flex flex-wrap text-xs py-2">
-        {#each tagInfo as tag}
+        {#each resource.tags as tag}
           <div
             class="bg-gray-200 rounded-lg whitespace-nowrap p-1 my-1 mr-2 "
             style:background-color={tag.color}


### PR DESCRIPTION
## Describe your changes
- Add colours to tags in yml that pass contrast with black text & description in schema
- Add the colours to the Resource tag list
- Show the colours as the background on filter tags and the card tags
- Adjust the cards to grow to the height of its row 

<img width="1003" alt="Screen Shot 2023-06-04 at 9 09 14 PM" src="https://github.com/ClimateTown/knowledge-hub/assets/4835191/a8355ffc-e0c0-421c-aa54-50807158bf6a">
<img width="992" alt="Screen Shot 2023-06-04 at 9 09 22 PM" src="https://github.com/ClimateTown/knowledge-hub/assets/4835191/af28bd76-4b84-4d91-bef3-2e571d5f14ce">
<img width="1043" alt="Screen Shot 2023-06-04 at 9 17 05 PM" src="https://github.com/ClimateTown/knowledge-hub/assets/4835191/0eb966b6-d851-4655-bc63-3221eb45935b">



## Related issue number/link

Fixes https://github.com/ClimateTown/knowledge-hub/issues/221
Fixes https://github.com/ClimateTown/knowledge-hub/issues/68
