### PR TITLE
Update +page.svelte on homepage to reflect YouTuber criteria

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -76,7 +76,8 @@
   >
     <h3>YouTube Feed</h3>
     <div class="my-3 text-gray-500">
-      A feed of Climate Town videos (plus some of our popular favorites), right here in the Knowledge Hub!
+      A feed of Climate Town videos (plus some of our popular favorites), right
+      here in the Knowledge Hub!
     </div>
     <a
       href="{base}/youtube"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -76,7 +76,7 @@
   >
     <h3>YouTube Feed</h3>
     <div class="my-3 text-gray-500">
-      A feed of Climate Town videos, right here in the Knowledge Hub!
+      A feed of Climate Town videos (plus some of our popular favorites), right here in the Knowledge Hub!
     </div>
     <a
       href="{base}/youtube"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -76,7 +76,7 @@
   >
     <h3>YouTube Feed</h3>
     <div class="my-3 text-gray-500">
-      A feed of Climate Town videos (plus some of our popular favorites), right
+      A feed of Climate Town and various other climate YouTuber videos, right
       here in the Knowledge Hub!
     </div>
     <a


### PR DESCRIPTION
New YouTubers beyond Climate Town have been added

## Describe your changes
Changed to reflect new channels while hinting at subscriber count threshold
## Related issue number/link

https://github.com/ClimateTown/knowledge-hub/issues/106#issuecomment-1546819336

