### PR TITLE
Disable URL checking workflow on forks

### DIFF
--- a/.github/workflows/url-checker.yml
+++ b/.github/workflows/url-checker.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   check-urls:
+    if: ${{ !github.event.repository.fork }}
     env:
       LYCHEE_REPORT_FILE: ./lychee/out.md
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Describe your changes

Workflow doesn't work on forks. Disabling.