### PR TITLE
adds SKIP TO CONTENT

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -53,6 +53,12 @@
   <header
     class="relative lg:w-fit w-full bg-green-500 dark:bg-green-900/75 flex items-center md:flex-col p-5 min-h-max lg:min-h-screen"
   >
+
+    <a href="#main-content" 
+      class="absolute p-10 mt-8 rounded-lg bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-50 -translate-x-[999%] focus:translate-x-0 hover:bg-zinc-800 hover:text-zinc-50 dark:hover:bg-zinc-50 dark:hover:text-zinc-800 transition-all duration-200 ease-in-out uppercase">
+        Skip to content.
+    </a>
+
     <a href="{base}/">
       <picture class="block w-32 lg:w-48 self-center object-contain">
         <source
@@ -112,7 +118,7 @@
     </nav>
   </header>
 
-  <main class="w-full lg:w-4/5 py-10 pb-5 lg:pt-24 lg:px-32 px-8">
+  <main id="main-content" class="w-full lg:w-4/5 py-10 pb-5 lg:pt-24 lg:px-32 px-8">
     <slot />
   </main>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -54,7 +54,7 @@
     class="relative lg:w-fit w-full bg-green-500 dark:bg-green-900/75 flex items-center md:flex-col p-5 min-h-max lg:min-h-screen"
   >
 
-    <a href="#main-content" 
+    <a href="#main-content"
       class="absolute p-10 mt-8 rounded-lg bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-50 -translate-x-[999%] focus:translate-x-0 hover:bg-zinc-800 hover:text-zinc-50 dark:hover:bg-zinc-50 dark:hover:text-zinc-800 transition-all duration-200 ease-in-out uppercase">
         Skip to content.
     </a>


### PR DESCRIPTION
Fixes #333

- Adds _Skip to Content_ link in header.
- Considers [main](https://github.com/ClimateTown/knowledge-hub/blob/63b37c0799c8269ff1a28ffeb4cc6e2450d9260a/src/routes/%2Blayout.svelte#L115) in `+layout.svelte` as main content.

|Desktop | Phone |
| :---------------------: | :---------------------: |
| ![skip-wide](https://github.com/ClimateTown/knowledge-hub/assets/129554482/4841ed44-4ad6-42a1-930f-1c7e6bb644b3) | ![skip](https://github.com/ClimateTown/knowledge-hub/assets/129554482/71df27b9-742b-4ad6-80bd-e827c7b9bc64) |

@dmlb Let me know if any changes are required. 🙂