### PR TITLE
Update onboarding schedule (from weekly to monthly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The "behind the scenes" of the [ClimateTown Knowledge Hub](https://climatetown.g
 - [Create an issue](https://github.com/ClimateTown/knowledge-hub/issues/new/choose) and select "✨Resource Suggestion".
 - Fill out the form. Please adhere to the instructions.
 - Get the resource approved (or discuss it further in the issue).
-- Once approved, resource is then onboarded onto the website. Resource onboarding happens every Friday!!
+- Once approved, resource is then onboarded onto the website. Resource onboarding happens at least once a month (on the first Sunday)!
 
 ## Contributing
 


### PR DESCRIPTION
## Describe your changes
Updated onboarding schedule to be on a monthly basis.

## Why?

The previous schedule of once a week was a bit unsustainable for me*, and I wasn't able to commit to it. A monthly freqeuncy is something I feel I can commit to, and would rather have a less frequent, but accurate frequency than one I didn't stick to.

If you would like to help with the onboarding of resources, please reach out to me on the Discord. Maybe we can get the frequency of these onboardings up.

\* and we are big fans of sustainability here