### PR TITLE
Patch download link filename

### DIFF
--- a/src/lib/components/ButtonLinks.svelte
+++ b/src/lib/components/ButtonLinks.svelte
@@ -13,7 +13,7 @@
   export let link: boolean = false
   export let url: string = "#"
   export let newTab: boolean = false
-  export let download: boolean | undefined = undefined
+  export let download: string | undefined = undefined
 
   let target: "_blank" | undefined
   let rel: string | undefined

--- a/src/lib/components/ResourceNav.svelte
+++ b/src/lib/components/ResourceNav.svelte
@@ -34,7 +34,7 @@
 
   <ButtonLinks
     link={true}
-    download={true}
+    download={""}
     url="{base}/ClimateTown-Knowledge-Hub-resources.csv"
     version="hollow"
     color="green"


### PR DESCRIPTION
## Describe your changes

Looks like the issue is in the [`download` \<a> attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attributes) (defined in `ButtonLinks.svelte`, called in `ResourceNav.svelte`)

Usecases:
1. Download file (original fname): `<a href="path-to-your-file.ext" download>Download File</a>`
2. Download file (custom fname): `<a href="path-to-your-file.ext" download="custom-filename.ext">Download File</a>`

`download` looks like it should be a string attribute, with an empty string corresponding to usecase 1 (as per the example in this PR https://github.com/sveltejs/svelte/pull/2804/files), while a custom string can override the file name (case 2).

Updating the data type and passed argument.

## Related issue number/link

<!-- If this PR resolves an issue, add "Fixes" before the number. E.g. "Fixes #x" -->

Fixes #345
