### PR TITLE
Patch pre-commit config (Svelte support in CI)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,5 +22,5 @@ repos:
         args: [--write] # edit files in-place
         additional_dependencies:
           - prettier
-          - prettier-plugin-svelte@v2.7.1
+          - prettier-plugin-svelte@v3.0.3
           - svelte

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "trailingComma": "es5",
-  "tabWidth": 2,
-  "semi": false,
-  "plugins": ["prettier-plugin-svelte"]
-}

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,8 @@
+const config = {
+  trailingComma: "es5",
+  tabWidth: 2,
+  semi: false,
+  plugins: [require.resolve("prettier-plugin-svelte")],
+}
+
+module.exports = config


### PR DESCRIPTION
## Describe your changes
Migrate to `.prettierrc.cjs` as mentioned in https://github.com/prettier/prettier/issues/15388#issuecomment-1717746872. Note that `.cjs` is used since in `package.json`, `"type": "module"` is used which declares all .js files in that package scope as ES modules. `.cjs` marks it explicitly as a common JS file.

## Related issue number/link

Fixes #349